### PR TITLE
유저 회원가입 로직 변경

### DIFF
--- a/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
@@ -2,12 +2,12 @@ package com.kkiri_trip.back.domain.user.controller;
 
 import com.kkiri_trip.back.domain.user.dto.Request.LoginRequestDto;
 import com.kkiri_trip.back.domain.user.dto.Request.SignUpRequestDto;
+import com.kkiri_trip.back.domain.user.dto.Request.UserProfileCreateRequestDto;
 import com.kkiri_trip.back.domain.user.dto.Request.UserUpdateRequestDto;
 import com.kkiri_trip.back.domain.user.dto.Response.LoginResponseDto;
 import com.kkiri_trip.back.domain.user.dto.Response.SignUpResponseDto;
 import com.kkiri_trip.back.domain.user.dto.Response.UserResponseDto;
 import com.kkiri_trip.back.domain.user.dto.Response.UserUpdateResponseDto;
-import com.kkiri_trip.back.domain.user.repository.UserRepository;
 import com.kkiri_trip.back.domain.user.service.UserService;
 import com.kkiri_trip.back.domain.user.util.CustomUserDetails;
 import com.kkiri_trip.back.global.common.dto.ApiResponseDto;
@@ -35,6 +35,12 @@ public class UserController {
     public ResponseEntity<ApiResponseDto<SignUpResponseDto>> register(@RequestBody @Valid SignUpRequestDto signUpRequestDto){
         SignUpResponseDto signUpResponseDto = userService.register(signUpRequestDto);
         return ApiResponseDto.from(HttpStatus.CREATED, "회원가입이 성공적으로 등록되었습니다.", signUpResponseDto);
+    }
+
+    @PostMapping("/register/profile")
+    public ResponseEntity<ApiResponseDto<UserProfileCreateRequestDto>> profileCreate(@RequestBody UserProfileCreateRequestDto userProfileCreateRequestDto){
+        userService.registerProfile(userProfileCreateRequestDto);
+        return ApiResponseDto.from(HttpStatus.OK, "프로필이 성공적으로 등록되었습니다.", userProfileCreateRequestDto);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
@@ -56,6 +56,12 @@ public class UserController {
         return ApiResponseDto.from(HttpStatus.OK, "모든 유저를 조회했습니다.", userResponseDtoList);
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponseDto<UserResponseDto>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+        UserResponseDto userResponseDto = userService.getMyInfo(userDetails.getUser());
+        return ApiResponseDto.from(HttpStatus.OK, "본인 정보를 조회했습니다.", userResponseDto);
+    }
+
     @PutMapping("/information")
     public ResponseEntity<ApiResponseDto<UserUpdateResponseDto>> updateUser(
                                                         @RequestBody UserUpdateRequestDto userUpdateRequestDto,

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Request/SignUpRequestDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Request/SignUpRequestDto.java
@@ -21,8 +21,6 @@ public class SignUpRequestDto {
     @NotBlank
     private String confirmPassword;
     private String name;
-    private String nickname;
     private String mobile_number;
-    private String profileUrl;
     private Gender gender;
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Request/UserProfileCreateRequestDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Request/UserProfileCreateRequestDto.java
@@ -1,0 +1,15 @@
+package com.kkiri_trip.back.domain.user.dto.Request;
+
+import com.kkiri_trip.back.global.enums.Gender;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileCreateRequestDto {
+    private String email;
+    private String nickname;
+    private String profileUrl;
+}

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/SignUpResponseDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/SignUpResponseDto.java
@@ -9,5 +9,5 @@ import lombok.*;
 @AllArgsConstructor
 public class SignUpResponseDto {
     private Long id;
-    private String nickname;
+    private String email;
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/UserResponseDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/UserResponseDto.java
@@ -12,12 +12,14 @@ public class UserResponseDto {
     private Long id;
     private String email;
     private String nickname;
+    private String profileUrl;
 
     public static UserResponseDto from(User user){
         return new UserResponseDto(
                 user.getId(),
                 user.getEmail(),
-                user.getNickname()
+                user.getNickname(),
+                user.getProfileUrl()
         );
     }
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/entity/User.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/entity/User.java
@@ -35,5 +35,9 @@ public class User extends BaseEntity {
     // private Long temperature
     // private Long review
 
+    public void createProfile(String nickname, String profileUrl) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
 
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/service/UserService.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/service/UserService.java
@@ -112,6 +112,10 @@ public class UserService {
                 .toList();
     }
 
+    public UserResponseDto getMyInfo(User user) {
+        return UserResponseDto.from(user);
+    }
+
     @Transactional
     public UserUpdateResponseDto updateUser(UserUpdateRequestDto userUpdateRequestDto, User loginUser){
         User user = userRepository.findById(loginUser.getId())
@@ -137,4 +141,6 @@ public class UserService {
 
         return new UserUpdateResponseDto(user.getId(),user.getEmail(), user.getNickname(), user.getProfileUrl());
     }
+
+
 }


### PR DESCRIPTION
- 회원가입 2단계 분리 
 -  회원가입 진행 -> 프로필 등록
 - 회원가입 POST /api/user/register
 - 프로필 등록 POST /api/user/register/profile
- 로그인 후 사용자 본인 조회 GET /api/user/me