### PR TITLE
Refactor: User 엔티티에서 프로필 및 PASS 인증 정보를 분리하여 역할 명확화

### DIFF
--- a/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController {
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponseDto<UserResponseDto>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
-        UserResponseDto userResponseDto = userService.getMyInfo(userDetails.getUser());
+        UserResponseDto userResponseDto = userService.getMyInfo(userDetails.getUser(), userDetails.getUser().getUserProfile());
         return ApiResponseDto.from(HttpStatus.OK, "본인 정보를 조회했습니다.", userResponseDto);
     }
 

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/LoginResponseDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/LoginResponseDto.java
@@ -8,7 +8,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginResponseDto {
-    private String accessToken;
+    private String email;
     private String nickname;
+    private String profileUrl;
+
 
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/UserResponseDto.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/dto/Response/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.kkiri_trip.back.domain.user.dto.Response;
 
 import com.kkiri_trip.back.domain.user.entity.User;
+import com.kkiri_trip.back.domain.user.entity.UserProfile;
 import lombok.*;
 
 @Getter
@@ -14,12 +15,12 @@ public class UserResponseDto {
     private String nickname;
     private String profileUrl;
 
-    public static UserResponseDto from(User user){
+    public static UserResponseDto from(User user, UserProfile userProfile){
         return new UserResponseDto(
                 user.getId(),
                 user.getEmail(),
-                user.getNickname(),
-                user.getProfileUrl()
+                userProfile.getNickname(),
+                userProfile.getProfileUrl()
         );
     }
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/entity/PassInfo.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/entity/PassInfo.java
@@ -1,0 +1,29 @@
+package com.kkiri_trip.back.domain.user.entity;
+
+import com.kkiri_trip.back.domain.common.entity.BaseEntity;
+import com.kkiri_trip.back.global.enums.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "passInfo")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PassInfo extends BaseEntity {
+    // TODO : 추후 Pass 연동 후 정보 제공
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String mobile_number;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/kkiri_trip/back/domain/user/entity/User.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.kkiri_trip.back.domain.user.entity;
 
 import com.kkiri_trip.back.domain.common.entity.BaseEntity;
-import com.kkiri_trip.back.global.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,26 +18,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    private String nickname;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private UserProfile userProfile;
 
-    private String profileUrl;
-
-    // TODO : 추후 Pass 연동 후 정보 제공
-//    @Column(nullable = false)
-    private String name;
-
-//    @Column(nullable = false)
-    private String mobile_number;
-
-    @Enumerated(EnumType.STRING)
-    private Gender gender;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private PassInfo passInfo;
 
     // private Long temperature
     // private Long review
-
-    public void createProfile(String nickname, String profileUrl) {
-        this.nickname = nickname;
-        this.profileUrl = profileUrl;
-    }
-
 }

--- a/src/main/java/com/kkiri_trip/back/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/entity/UserProfile.java
@@ -1,0 +1,30 @@
+package com.kkiri_trip.back.domain.user.entity;
+
+import com.kkiri_trip.back.domain.common.entity.BaseEntity;
+import com.kkiri_trip.back.global.enums.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "userProfile")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfile extends BaseEntity {
+    @Column(nullable = false)
+    private String nickname;
+    @Column(nullable = false)
+    private String profileUrl;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public void createProfile(String nickname, String profileUrl) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
+
+}

--- a/src/main/java/com/kkiri_trip/back/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/repository/UserProfileRepository.java
@@ -1,0 +1,10 @@
+package com.kkiri_trip.back.domain.user.repository;
+
+import com.kkiri_trip.back.domain.user.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/kkiri_trip/back/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kkiri_trip/back/domain/user/repository/UserRepository.java
@@ -11,6 +11,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
-
-    boolean existsByNickname(String nickname);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,26 +1,33 @@
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test1@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터1', 'tester1', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO users (email, password, created_at, updated_at) VALUES
+('test1@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test2@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test3@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test4@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test5@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test6@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test7@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('test8@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test2@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터2', 'tester2', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO user_profile (nickname, profile_url, user_id, created_at, updated_at) VALUES
+('tester1', 'https://example.com/default.jpg', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester2', 'https://example.com/default.jpg', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester3', 'https://example.com/default.jpg', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester4', 'https://example.com/default.jpg', 4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester5', 'https://example.com/default.jpg', 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester6', 'https://example.com/default.jpg', 6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester7', 'https://example.com/default.jpg', 7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('tester8', 'https://example.com/default.jpg', 8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test3@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터3', 'tester3', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO pass_info (name, mobile_number, gender, user_id, created_at, updated_at) VALUES
+('테스터1', '01000000001', 'M', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터2', '01000000002', 'M', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터3', '01000000003', 'M', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터4', '01000000004', 'M', 4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터5', '01000000005', 'M', 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터6', '01000000006', 'F', 6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터7', '01000000007', 'F', 7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('테스터8', '01000000008', 'F', 8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test4@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터4', 'tester4', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test5@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터5', 'tester5', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test6@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터6', 'tester6', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test7@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터7', 'tester7', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO users (email, password, name, nickname, mobile_number, gender, created_at, updated_at) VALUES
-('test8@example.com', '$2b$12$wGz.CbY9tY3ABmGwRmIH4OM3b5alGer863Wh5oXemyJp4ztPfVO/a', '테스터8', 'tester8', '01000000001', 'M', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO feed (title, content, created_at, updated_at) VALUES
 ('제목1', '내용1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);


### PR DESCRIPTION
- 닉네임 및 프로필 이미지를 UserProfile로 분리
- 이름, 성별, 전화번호를 PassInfo 엔티티로 분리
- 연관관계 설정 및 cascade 적용